### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 from ubuntu:latest
 add . /src
 env DEBIAN_FRONTEND=noninteractive
-run apt-get update && apt-get install -y bc make bsdextrautils shellcheck \
-    rm -rf /var/cache/apt/archives /var/lib/apt/lists
+run apt-get update && apt-get install -y bc make bsdextrautils shellcheck 
+run rm -rf /var/cache/apt/archives /var/lib/apt/lists
 workdir /src


### PR DESCRIPTION
go this error before I made this change
```6.239 E: Command line option 'r' [from -rf] is not understood in combination with the other options.
------
Dockerfile:4
--------------------
   3 |     env DEBIAN_FRONTEND=noninteractive
   4 | >>> run apt-get update && apt-get install -y bc make bsdextrautils shellcheck \
   5 | >>>     rm -rf /var/cache/apt/archives /var/lib/apt/lists && \
   6 | >>> workdir /src
   7 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && apt-get install -y bc make bsdextrautils shellcheck     rm -rf /var/cache/apt/archives /var/lib/apt/lists && workdir /src" did not complete successfully: exit code: 100
jamesstroud@Jamess-MacBook-Pro-2 mdye-shell-samples % vi Dockerfile 
jamesstroud@Jamess-MacBook-Pro-2 mdye-shell-samples % docker build -t localhost/shell-samples .
```
the directories we are removing are in the image but my original command did not work.  So I boke out into 2 lines